### PR TITLE
Update config to use environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# TCM
+
+This Flask-based Test Case Management application uses SQLAlchemy for data storage. 
+
+## Configuration
+
+The application reads configuration from environment variables with the following defaults:
+
+- `SECRET_KEY`: defaults to `change-me`.
+- `SQLALCHEMY_DATABASE_URI`: defaults to `sqlite:///test_management.db`.
+
+Set these variables in your environment when running the app to customize the secret key and database location.
+
+## Running
+
+Create a virtual environment and install dependencies (Flask, Flask-Login, Flask-Migrate, SQLAlchemy). Then run:
+
+```bash
+python app.py
+```
+
+The database file will be created automatically if it does not exist.

--- a/app.py
+++ b/app.py
@@ -1,14 +1,15 @@
 from flask import Flask, render_template, request, redirect, url_for, flash
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager, UserMixin, login_user, login_required, logout_user, current_user
+import os
 from werkzeug.security import generate_password_hash, check_password_hash
 import datetime
 from flask_migrate import Migrate
 from sqlalchemy.sql import func
 import xml.etree.ElementTree as ET
 app = Flask(__name__)
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///test_management.db'
-app.config['SECRET_KEY'] = 'asdf1234!@#$asdf1234!@#$'  # 실제 사용 시 랜덤값으로 변경
+app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('SQLALCHEMY_DATABASE_URI', 'sqlite:///test_management.db')
+app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'change-me')  # 실제 사용 시 랜덤값으로 변경
 db = SQLAlchemy(app)
 migrate = Migrate(app, db)
 # 로그인 관리 설정


### PR DESCRIPTION
## Summary
- make `SECRET_KEY` and `SQLALCHEMY_DATABASE_URI` configurable via environment variables
- add README describing configuration

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6875b3809ec08325971b84764b7f3247