### PR TITLE
Improve XML upload safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ python app.py
 ```
 
 The database file will be created automatically if it does not exist.
+
+## File Uploads
+
+XML uploads are limited to 2MB. Uploaded files are saved using `secure_filename`
+and deleted after processing. Malformed XML or duplicate test cases are skipped
+with warnings.


### PR DESCRIPTION
## Summary
- add a max upload size and secure filenames
- skip duplicate cases and show warnings
- document file upload behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875b403aa4c8325a526b020abd4f4e2