### PR TITLE
Add automatic DB creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ Set these variables when running the app if you need to customize the secret key
 
 ## Database initialization
 
-The bundled `app.py` automatically creates the database if it does not exist:
 
-```bash
-python app.py  # creates test_management.db under ./instance
-```
+The app automatically creates the database when it starts. Run it with
+`python app.py` or `flask run` and a new `test_management.db` will appear under
+`./instance` if it is missing.
+
+If you previously ran the app before a model was added (for example the
+`Project` table), remove the old `instance/test_management.db` so the new
+schema can be created or use migrations to upgrade the database.
 
 If you prefer using migrations, initialize them before running:
 

--- a/app.py
+++ b/app.py
@@ -19,6 +19,10 @@ login_manager = LoginManager()
 login_manager.init_app(app)
 login_manager.login_view = 'login'
 
+# Automatically create tables when the application starts
+with app.app_context():
+    db.create_all()
+
 
 # DB 모델 정의
 class User(UserMixin, db.Model):


### PR DESCRIPTION
## Summary
- automatically create tables when the app starts so it works with `flask run`
- update README to mention automatic DB creation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6875c2cff5188325b7251fd8321b3f07